### PR TITLE
Enable websockets via omero-web nginx config

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -29,9 +29,11 @@
         # Needed for OMERO.figure export
         - markdown
         - reportlab
+      omero_server_config_set:
+        # Enable web-sockets
+        omero.client.icetransports: ssl,tcp,wss
       ## Uncomment to scale up for more users.
       # Disabling permits testing on smaller VMs.
-      # omero_server_config_set:
       #   omero.db.poolsize: 50
       #   omero.jvmcfg.percent.blitz: 50
       #   omero.jvmcfg.percent.indexer: 20
@@ -55,8 +57,16 @@
           script_ui|ome_tiff|figure_script))|\
           webgateway/(?!(archived_files|download_as))\
           |iviewer/|mapr/|figure/)"
+        omero.web.nginx_server_extra_config:
+          # Proxy websockets through Nginx alongside OMERO.web
+          - location ~ ^/omero-ws(/.*)?$ {
+          - proxy_pass https://localhost:4066;
+          - proxy_http_version 1.1;
+          - proxy_set_header Upgrade $http_upgrade;
+          - proxy_set_header Connection "Upgrade";
+          - proxy_read_timeout 86400;
+          - "}"
         # Uncomment to configure SSL certificates
-        # omero.web.nginx_server_extra_config:
         #   - "listen 443 ssl;"
         #   - "ssl_certificate {{ ssl_certificate_public_path }};"
         #   - "ssl_certificate_key {{ ssl_certificate_key_path }};"

--- a/playbook.yml
+++ b/playbook.yml
@@ -140,6 +140,14 @@
 
   tasks:
 
+    - name: selinux nginx allow omero wss
+      become: true
+      seboolean:
+        name: httpd_can_network_connect
+        state: true
+        persistent: true
+      when: selinux_enabled
+
     - name: Copy Figure_To_Pdf.py script
       become: true
       become_user: omero-server


### PR DESCRIPTION
This will require an selinux boolean to be changed, perhaps in https://github.com/ome/ansible-role-omero-web/blob/3.1.0/tasks/web-dependencies.yml#L4-L13, to allow Nginx to connect to port 4066 since it's not a "standard" http/proxy port:
```
# audit2allow -a


#============= httpd_t ==============

#!!!! This avc can be allowed using one of the these booleans:
#     httpd_can_network_connect, nis_enabled
allow httpd_t unreserved_port_t:tcp_socket name_connect;
```