### PR TITLE
Use ome.omero_server 4.0.1 and remove unnecessary pre-task

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -8,17 +8,7 @@
       when: ansible_facts['os_family'] == "Debian"
 
 - hosts: omero-addons
-
-  pre_tasks:
-
-    - name: Ensure openssl is installed
-      become: true
-      package:
-        name: openssl
-        state: present
-
   roles:
-
     - role: ome.postgresql
       postgresql_databases:
         - name: omero
@@ -42,11 +32,6 @@
       #   omero.jvmcfg.percent.indexer: 20
       #   omero.jvmcfg.percent.pixeldata: 20
 
-      # These two are optional on Centos, required on Ubuntu
-      # For more information on why omero_server_selfsigned_certificates
-      # is required see
-      # https://forum.image.sc/t/omero-icessl-unable-to-set-ciphers/30704
-      omero_server_systemd_require_network: false
       omero_server_selfsigned_certificates: true
 
     - role: ome.omero_web

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@
   version: 5.0.2
 
 - src: ome.omero_server
-  version: 4.0.0
+  version: 4.0.1
 
 - src: ome.omero_web
   version: 4.0.0


### PR DESCRIPTION
- openssl should be installed as part of the role
- also remove deprecated omero_server_systemd_require_network variable

Noticed while handling https://forum.image.sc/t/automated-omero-installation-w-ansible/52974, this should simplify the playbook to use the latest features of the role